### PR TITLE
아이템 상세 모달 기능 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-<img width="583" alt="trash-can-banner" src="https://github.com/threeehouse/trash-can/assets/47452547/40ebf52c-705e-4ccf-991d-4b01b0379246">
+<img width="100%" alt="trash-can-banner" src="https://github.com/threeehouse/trash-can/assets/47452547/40ebf52c-705e-4ccf-991d-4b01b0379246">
 
 # Introduce
-![trash-can-intro](https://github.com/threeehouse/trash-can/assets/47452547/aa401663-74f4-4ba9-aefc-33948b5de07f)
+![trash-can-intro](https://github.com/threeehouse/trash-can/assets/47452547/e7c6f465-0e77-4406-ad19-aff288e609b4)
+
 - 정든 쓰레기를 올리는 공간입니다.
 - 불쾌할 수 있는 게시물을 방지하기 위해 기본적으로 블러처리 되어있습니다.
 - SSR과 SSG를 활용하였습니다.

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -21,6 +21,7 @@ interface Props extends Omit<HTMLMotionProps<'button'>, 'type'> {
   buttonStyle?: React.CSSProperties;
   disabled?: boolean;
   htmlType?: ButtonHTMLType;
+  icon?: React.ReactNode;
   children: React.ReactNode;
 }
 
@@ -71,6 +72,7 @@ export function Button({
   disabled,
   buttonStyle,
   htmlType,
+  icon,
   children,
   ...rest
 }: Props) {
@@ -86,6 +88,7 @@ export function Button({
       type={htmlType}
       {...rest}
     >
+      {icon}
       <Text color={BUTTON_TEXT_COLOR[type]} variant={BUTTON_TEXT_SIZE[size]}>
         {children}
       </Text>
@@ -103,7 +106,7 @@ const StyledButton = styled(motion.button)<{
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 14px;
+  gap: 12px;
   font-weight: 700;
   font-size: 16px;
 

--- a/src/components/Item/index.tsx
+++ b/src/components/Item/index.tsx
@@ -47,7 +47,7 @@ const descVariant = {
 
 type ItemProps = ItemType & Partial<HTMLMotionProps<'button'>>;
 
-export function Item({ imgUrl, pray, title }: ItemProps) {
+export function Item({ imgUrl, pray, title, _id }: ItemProps) {
   const [hovered, setHovered] = useState(false);
   const openItemModal = useDetailItemModal();
 
@@ -59,7 +59,7 @@ export function Item({ imgUrl, pray, title }: ItemProps) {
         whileInView="animate"
         viewport={{ once: true }}
         onClick={() => {
-          openItemModal({ imgUrl, pray, title });
+          openItemModal({ imgUrl, title, _id });
         }}
         onMouseEnter={() => {
           setHovered(true);

--- a/src/hooks/modal/Modal.tsx
+++ b/src/hooks/modal/Modal.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { AnimatePresence, motion } from 'framer-motion';
 
 import { PreventClickEvent } from '../../components';
 import { theme } from '../../theme';
@@ -10,20 +11,37 @@ interface Props {
 }
 
 export function Modal({ isOpen, close, children }: Props) {
-  return isOpen ? (
-    <Dimmer
-      onClick={() => {
-        close();
-      }}
-    >
-      <PreventClickEvent>
-        <StyledModal>{children}</StyledModal>
-      </PreventClickEvent>
-    </Dimmer>
-  ) : null;
+  return (
+    <AnimatePresence>
+      {isOpen ? (
+        <Dimmer
+          onClick={() => {
+            close();
+          }}
+        >
+          <PreventClickEvent>
+            <StyledModal
+              initial={{
+                opacity: 0,
+              }}
+              animate={{
+                opacity: 1,
+              }}
+              exit={{
+                opacity: 0,
+              }}
+              transition={{ duration: 0.3 }}
+            >
+              {children}
+            </StyledModal>
+          </PreventClickEvent>
+        </Dimmer>
+      ) : null}
+    </AnimatePresence>
+  );
 }
 
-const StyledModal = styled.div`
+const StyledModal = styled(motion.div)`
   text-align: center;
   padding: 28px;
   width: 450px;

--- a/src/hooks/modal/useDetailItemModal.tsx
+++ b/src/hooks/modal/useDetailItemModal.tsx
@@ -38,7 +38,7 @@ function DetailItem({ imgUrl, title }: Props) {
       <Image src={imgUrl} alt={title} width={380} height={380} mode="cover" css={{ marginBottom: '20px' }} />
       <Button
         type="general"
-        width={180}
+        width={200}
         disabled={clicked}
         icon={<Image src="/icon/pray.png" alt="pray Icon" width={20} height={20} />}
         onClick={() => {

--- a/src/hooks/modal/useDetailItemModal.tsx
+++ b/src/hooks/modal/useDetailItemModal.tsx
@@ -34,14 +34,14 @@ function DetailItem({ imgUrl, pray, title }: Props) {
         {title}
       </Text>
       <Image src={imgUrl} alt={title} width={380} height={380} mode="cover" css={{ marginBottom: '20px' }} />
-      {/* <Text variant="headline" color='gray030' css={{ marginBottom: '15px' }}>
-        Please Pray For This
-      </Text> */}
       <Button
         type={clicked ? 'primary' : 'general'}
-        width={200}
+        width={100}
+        icon={<Image src="/icon/pray.png" alt="pray Icon" width={20} height={20} />}
         onClick={() => setClicked(true)}
-      >{`Pray ${pray}`}</Button>
+      >
+        {pray}
+      </Button>
     </StyledDetailItem>
   );
 }

--- a/src/hooks/modal/useDetailItemModal.tsx
+++ b/src/hooks/modal/useDetailItemModal.tsx
@@ -1,8 +1,10 @@
 import styled from '@emotion/styled';
-import { useState } from 'react';
+import { motion } from 'framer-motion';
+import { ComponentProps, useEffect, useState } from 'react';
 
 import { Modal } from './Modal';
 import { Button, Image, Text } from '../../components';
+import { theme } from '../../theme';
 import { overlayKey, useOverlay } from '../overlay';
 
 export const useDetailItemModal = () => {
@@ -19,12 +21,12 @@ export const useDetailItemModal = () => {
 
 interface Props {
   imgUrl: string;
-  pray: number;
   title: string;
 }
 
-function DetailItem({ imgUrl, pray, title }: Props) {
+function DetailItem({ imgUrl, title }: Props) {
   const [clicked, setClicked] = useState(false);
+  const overlay = useOverlay(overlayKey.MESSAGE);
   return (
     <StyledDetailItem>
       <Text variant="title04" as="h4" color="primary" css={{ marginTop: '10px' }}>
@@ -35,16 +37,57 @@ function DetailItem({ imgUrl, pray, title }: Props) {
       </Text>
       <Image src={imgUrl} alt={title} width={380} height={380} mode="cover" css={{ marginBottom: '20px' }} />
       <Button
-        type={clicked ? 'primary' : 'general'}
-        width={100}
+        type="general"
+        width={180}
+        disabled={clicked}
         icon={<Image src="/icon/pray.png" alt="pray Icon" width={20} height={20} />}
-        onClick={() => setClicked(true)}
+        onClick={() => {
+          // API Call
+          setClicked(true);
+          overlay.open(({ isOpen, close }) => <TextBalloon isOpen={isOpen} close={close} />);
+        }}
       >
-        {pray}
+        {clicked ? 'Thank you' : 'Pray for me'}
       </Button>
     </StyledDetailItem>
   );
 }
+
+function TextBalloon({ isOpen, close }: Omit<ComponentProps<typeof Modal>, 'children'>) {
+  const messages = ['Thank you Bro', 'God Bless You', 'Bye Bye ....'];
+  useEffect(() => {
+    new Promise<void>(resolve => {
+      setTimeout(() => {
+        resolve();
+      }, 2000);
+    }).then(() => {
+      close();
+    });
+  });
+  return isOpen ? (
+    <StyledTextBalloon>
+      <Text variant="subhead" color="gray120">
+        {messages[Math.floor(Math.random() * messages.length)]}
+      </Text>
+    </StyledTextBalloon>
+  ) : null;
+}
+
+const StyledTextBalloon = styled(motion.div)`
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  position: fixed;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 200px;
+  height: 70px;
+  border: 1px solid ${theme.colors.gray120};
+  border-radius: 100%;
+  background-color: ${theme.colors.white};
+  z-index: 101;
+`;
 
 const StyledDetailItem = styled('div')`
   display: flex;

--- a/src/hooks/modal/useDetailItemModal.tsx
+++ b/src/hooks/modal/useDetailItemModal.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { motion } from 'framer-motion';
+import { AnimatePresence, motion } from 'framer-motion';
 import { ComponentProps, useEffect, useState } from 'react';
 
 import { Modal } from './Modal';
@@ -64,25 +64,48 @@ function TextBalloon({ isOpen, close }: Omit<ComponentProps<typeof Modal>, 'chil
       close();
     });
   });
-  return isOpen ? (
-    <StyledTextBalloon>
-      <Text variant="subhead" color="gray120">
-        {messages[Math.floor(Math.random() * messages.length)]}
-      </Text>
-    </StyledTextBalloon>
-  ) : null;
+  return (
+    <AnimatePresence>
+      {isOpen ? (
+        <StyledTextBalloon
+          initial={{
+            x: '-50%',
+            y: '-50%',
+            scale: 1.3,
+            opacity: 0,
+          }}
+          animate={{
+            x: '-50%',
+            y: '-50%',
+            scale: 1,
+            opacity: 1,
+          }}
+          exit={{
+            x: '-50%',
+            y: '-50%',
+            scale: 1.3,
+            opacity: 0,
+          }}
+          transition={{ duration: 0.7 }}
+        >
+          <Text variant="headline" color="gray120">
+            {messages[Math.floor(Math.random() * messages.length)]}
+          </Text>
+        </StyledTextBalloon>
+      ) : null}
+    </AnimatePresence>
+  );
 }
 
 const StyledTextBalloon = styled(motion.div)`
   top: 50%;
   left: 50%;
-  transform: translate(-50%, -50%);
   position: fixed;
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 200px;
-  height: 70px;
+  width: 230px;
+  height: 90px;
   border: 1px solid ${theme.colors.gray120};
   border-radius: 100%;
   background-color: ${theme.colors.white};

--- a/src/hooks/modal/useDetailItemModal.tsx
+++ b/src/hooks/modal/useDetailItemModal.tsx
@@ -5,11 +5,13 @@ import { ComponentProps, useEffect, useState } from 'react';
 import { Modal } from './Modal';
 import { Button, Image, Text } from '../../components';
 import { theme } from '../../theme';
+import { Item } from '../../type';
+import { http } from '../../utils';
 import { overlayKey, useOverlay } from '../overlay';
 
 export const useDetailItemModal = () => {
   const overlay = useOverlay(overlayKey.HOME);
-  const openItemModal = (props: Props) => {
+  const openItemModal = (props: ComponentProps<typeof DetailItem>) => {
     overlay.open(({ isOpen, close }) => (
       <Modal isOpen={isOpen} close={close}>
         <DetailItem {...props} />
@@ -19,12 +21,7 @@ export const useDetailItemModal = () => {
   return openItemModal;
 };
 
-interface Props {
-  imgUrl: string;
-  title: string;
-}
-
-function DetailItem({ imgUrl, title }: Props) {
+function DetailItem({ imgUrl, title, _id }: Omit<Item, 'pray' | 'userIP'>) {
   const [clicked, setClicked] = useState(false);
   const overlay = useOverlay(overlayKey.MESSAGE);
   return (
@@ -41,8 +38,8 @@ function DetailItem({ imgUrl, title }: Props) {
         width={200}
         disabled={clicked}
         icon={<Image src="/icon/pray.png" alt="pray Icon" width={20} height={20} />}
-        onClick={() => {
-          // API Call
+        onClick={async () => {
+          await http.patch('/home/item/pray', { itemId: _id });
           setClicked(true);
           overlay.open(({ isOpen, close }) => <TextBalloon isOpen={isOpen} close={close} />);
         }}

--- a/src/hooks/overlay/key.ts
+++ b/src/hooks/overlay/key.ts
@@ -1,3 +1,4 @@
 export const overlayKey = {
   HOME: 'HOME',
+  MESSAGE: 'MESSAGE',
 };

--- a/src/pages/api/home/item/pray/index.ts
+++ b/src/pages/api/home/item/pray/index.ts
@@ -6,7 +6,7 @@ import { ItemModel } from '../../../model';
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   connectDB();
   const { body, method } = req;
-  if (!['POST'].includes(method ?? '')) {
+  if (!['PATCH'].includes(method ?? '')) {
     return res.status(405).json({
       isSuccess: false,
       message: '허용되지 않은 메서드 입니다.',

--- a/src/pages/api/home/item/pray/index.ts
+++ b/src/pages/api/home/item/pray/index.ts
@@ -1,0 +1,47 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import connectDB from '../../../connectDB';
+import { ItemModel } from '../../../model';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  connectDB();
+  const { body, method } = req;
+  if (!['POST'].includes(method ?? '')) {
+    return res.status(405).json({
+      isSuccess: false,
+      message: '허용되지 않은 메서드 입니다.',
+    });
+  }
+
+  if (!['itemId'].every(property => property in body)) {
+    return res.status(400).json({
+      isSuccess: false,
+      message: '올바르지 않은 필드 값 입니다.',
+    });
+  }
+
+  const { itemId } = body;
+
+  try {
+    const existingItem = await ItemModel.findById(itemId);
+    if (!existingItem) {
+      return res.status(404).json({
+        isSuccess: false,
+        message: '아이템을 찾을 수 없습니다.',
+      });
+    }
+
+    existingItem.pray += 1;
+    const result = await existingItem.save();
+    return res.status(200).json({
+      isSuccess: true,
+      message: '아이템 기도하기에 성공하였습니다.',
+      result,
+    });
+  } catch {
+    return res.status(500).json({
+      isSuccess: false,
+      message: '아이템 기도하기에 실패하였습니다.',
+    });
+  }
+}


### PR DESCRIPTION
- 기도하기 버튼 디자인 : pray icon이 들어가야 자연스러울거 같아서 icon prop을 Button 컴포넌트에 추가함
- 기도하기 버튼에 대해서 나름대로 엄청나게 고민함 : 기도하기 숫자는 모달에서 안보이게 하고 버튼만 두기로 결정
- 기도하기 버튼을 연타하는 것을 방지하기 위하여 (사실 상관 없는데 서버가 터질까봐) 모달에서 버튼을 누르면 disabled되게 함
- 사실 userIP로 한번 기도한 아이템에 대해서 다시 기도api를 보내는 것을 방지하려 했으나... 사용자가 많이 없을거 같아서 일단 구현 안함
- 기도하기를 어떻게 하면 허전하게 하지 않을까 하다가 말풍선을 2초간 나타나게 함
- 기도하기 patch api를 개발하여 버튼이 클릭되면 기도하기 숫자가 상승되게 함
- 모달을 닫으면 refetch가 되게 해야하는데 일단은 작업 마무리 추후 feature로 미룸